### PR TITLE
JAVACLIENT-102: unsupported date handling v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ document = nuxeoClient.repository().createDocumentByPath("/folder_1", document);
 ```
 
 ```java
+// Handle date using ISO 8601 format
+Document document = new Document("file", "File");
+document.set("dc:issued", "2017-02-09T00:00:00.000+01:00");
+```
+
+When handling date object, such as `java.time.ZonedDateTime` or `java.util.Calendar`, it should be converted to string
+as ISO 8601 date format "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" before calling `Document#set(String, Object)`. Otherwise, an
+exception will be thrown by the document.
+
+However, if you try to set / reset the document properties using `Document#setProperties(Map)`, we don't have any check
+for its date objects and these dates won't be created / updated correctly after the exchange with Nuxeo Server. So, to
+ensure the correctness of date handling, please always convert date to ISO 8601 date format before using Nuxeo Java
+Client.
+
+```java
 // Update a document
 Document document = nuxeoClient.repository().fetchDocumentByPath("/folder_1/note_0");
 Document documentUpdated = new Document("test update", "Note");

--- a/nuxeo-java-client-test/src/test/java/org/nuxeo/client/test/TestCurrentUser.java
+++ b/nuxeo-java-client-test/src/test/java/org/nuxeo/client/test/TestCurrentUser.java
@@ -32,7 +32,11 @@ import org.nuxeo.ecm.core.test.annotations.Granularity;
 import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
 import org.nuxeo.ecm.restapi.test.RestServerFeature;
 import org.nuxeo.ecm.restapi.test.RestServerInit;
-import org.nuxeo.runtime.test.runner.*;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.Jetty;
+import org.nuxeo.runtime.test.runner.LocalDeploy;
 
 /**
  * @since 0.1

--- a/nuxeo-java-client-test/src/test/java/org/nuxeo/client/test/TestRepository.java
+++ b/nuxeo-java-client-test/src/test/java/org/nuxeo/client/test/TestRepository.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2016-2017 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *         Vladimir Pasquier <vpasquier@nuxeo.com>
+ *         Mincong Huang <mhuang@nuxeo.com>
  */
 package org.nuxeo.client.test;
 
@@ -158,7 +159,7 @@ public class TestRepository extends TestBase {
 
     @Test
     public void itCanQuery() {
-        Documents documents = nuxeoClient.repository().query("SELECT * " + "From Note");
+        Documents documents = nuxeoClient.repository().query("SELECT * From Note");
         assertTrue(documents.getDocuments().size() != 0);
         Document document = documents.getDocuments().get(0);
         assertEquals("Note", document.getType());
@@ -251,7 +252,7 @@ public class TestRepository extends TestBase {
     @Test
     public void itCanUseQueriesAndResultSet() {
         RecordSet documents = (RecordSet) nuxeoClient.automation()
-                                                     .param("query", "SELECT " + "* FROM Document")
+                                                     .param("query", "SELECT * FROM Document")
                                                      .execute("Repository.ResultSetQuery");
         assertTrue(documents.getUuids().size() != 0);
     }
@@ -350,8 +351,7 @@ public class TestRepository extends TestBase {
         Thread t = new Thread(() -> {
             try {
                 RecordSet documents = nuxeoClient.automation()
-                                                 .param("query", "SELECT * " +
-                                                         "FROM Document")
+                                                 .param("query", "SELECT * FROM Document")
                                                  .execute("Repository.ResultSetQuery");
                 assertTrue(documents.getUuids().size() != 0);
             } catch (Exception e) {

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/api/objects/Document.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/api/objects/Document.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2016-2017 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,8 +165,8 @@ public class Document extends NuxeoEntity {
     }
 
     /**
-     * This constructor is providing a way to create 'adapters' of a document. See
-     * org.nuxeo.client.test.objects.DataSet in nuxeo-java-client-test.
+     * This constructor is providing a way to create 'adapters' of a document. See org.nuxeo.client.test.objects.DataSet
+     * in nuxeo-java-client-test.
      *
      * @since 1.0
      * @param document the document to copy from the sub class.
@@ -429,7 +429,7 @@ public class Document extends NuxeoEntity {
 
     /**
      * Add permission on the current document by passing the related email.
-     * 
+     *
      * @since 1.0
      * @param ace the permission.
      * @param email the invited email.

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/api/objects/Document.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/api/objects/Document.java
@@ -20,12 +20,16 @@ package org.nuxeo.client.api.objects;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import okhttp3.ResponseBody;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.client.api.ConstantsV1;
 import org.nuxeo.client.api.objects.acl.ACE;
 import org.nuxeo.client.api.objects.acl.ACL;
@@ -45,6 +49,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * @since 0.1
  */
 public class Document extends NuxeoEntity {
+
+    private static final Logger logger = LogManager.getLogger(Document.class);
+
+    public static final String MSG_DATE_UNSUPPORTED = "Date values are not supported in Nuxeo Java Client. Please"
+            + "convert it to String with ISO 8601 format \"yyyy-MM-dd'T'HH:mm:ss.SSXXX\" before calling this method.";
 
     protected String path;
 
@@ -278,6 +287,9 @@ public class Document extends NuxeoEntity {
     }
 
     public void set(String key, Object value) {
+        if (value instanceof Calendar || value instanceof Date) {
+            throw new IllegalArgumentException(MSG_DATE_UNSUPPORTED);
+        }
         properties.put(key, value);
         dirtyProperties.put(key, value);
     }


### PR DESCRIPTION
https://jira.nuxeo.com/browse/JAVACLIENT-102

This PR aims to provide more explanation about the date handling in the Nuxeo Java Client:

- It explains the expected ISO 8601 date string format in README.
- It provides associated test cases showing how date can / cannot be handled in different circumstances.

But please be aware that it is a workaround solution. The date objects are still not supported by Nuxeo Java Client due to the constraint of object reflection in Retrofit.