### PR TITLE
JAVACLIENT-102: fixup PR #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,13 +216,8 @@ document.set("dc:issued", "2017-02-09T00:00:00.000+01:00");
 ```
 
 When handling date object, such as `java.time.ZonedDateTime` or `java.util.Calendar`, it should be converted to string
-as ISO 8601 date format "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" before calling `Document#set(String, Object)`. Otherwise, an
-exception will be thrown by the document.
-
-However, if you try to set / reset the document properties using `Document#setProperties(Map)`, we don't have any check
-for its date objects and these dates won't be created / updated correctly after the exchange with Nuxeo Server. So, to
-ensure the correctness of date handling, please always convert date to ISO 8601 date format before using Nuxeo Java
-Client.
+as ISO 8601 date format "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" before calling the constructor or any setter method, e.g.
+`Document#set(String, Object)`. Otherwise, an exception will be thrown by the document.
 
 ```java
 // Update a document


### PR DESCRIPTION
Based on the feedback of PR #15, here's a fixup for PR #14 which aims to:

1. Remove unused import in `Document.java`
2. Convert date values check for document's properties and dirty properties
3. Unit-test the check, including:
   1. check when a date value is detected in a schema's field
   2. check when at least one date value is detected in a schema's field as a member of an array or a collection
4. Update README. Properties check wasn't covered previously, but now it's covered.
