### PR TITLE
Reconnect Blob Content-Type

### DIFF
--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/api/objects/NuxeoEntity.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/api/objects/NuxeoEntity.java
@@ -257,6 +257,11 @@ public abstract class NuxeoEntity<T> {
                     }
                     ((Blob) entity).setFileName(fileName);
                 }
+
+                String contentType = headers.get("Content-Type")
+                if (contentType != null) {
+                    ((Blob) entity).setMimeType(contentType);
+                }
             }
             return entity;
         } else if (entity instanceof List<?>) {


### PR DESCRIPTION
The Content-Type header is not copied from the API call to the Blob like the Content-Disposition is.