### PR TITLE
Fix IllegalArgumentException: Unexpected char 0x0a when login:password base64 length > 76

### DIFF
--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/internals/spi/auth/BasicAuthInterceptor.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/internals/spi/auth/BasicAuthInterceptor.java
@@ -41,7 +41,7 @@ public class BasicAuthInterceptor implements Interceptor {
 
     public void setAuth(String username, String password) {
         String info = username + ":" + password;
-        token = "Basic " + Base64.encode(info);
+        token = "Basic " + Base64.encode(info, Base64.DONT_BREAK_LINES);
     }
 
     @Override

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/internals/util/Base64.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/internals/util/Base64.java
@@ -215,6 +215,10 @@ public class Base64 {
         return encodeBytes(content.getBytes());
     }
 
+    public static String encode(String content, int options) {
+        return encodeBytes(content.getBytes(), options);
+    }
+
     public static String encode(String content, String charset) throws UnsupportedEncodingException {
         return encodeBytes(content.getBytes(charset));
     }


### PR DESCRIPTION
Exception :
IllegalArgumentException: Unexpected char 0x0a at 76
Test Case :
String login = "verylongmailaddress0123456789@test.com";
String password = "verylongpassword0123456789";
new NuxeoClient(login, password);
Explication :
BasicAuthInterceptor.setAuth generate the following base64 (length of 88) : 64dmVyeWxvbmdtYWlsYWRkcmVzczAxMjM0NTY3ODlAdGVzdC5jb206dmVyeWxvbmdwYXNzd29yZDAxMjM0NTY3ODk=
The maximum line length of Base64 output is 76
The method checkNameAndValue of okhttp3.Headers doesn't accept the character line break and throw the IllegalArgumentException.

This pull request fix this issue by specifying Base64.encode to not break lines.