### PR TITLE
JAVACLIENT-142: Ensure there's only one authentication method on clie…

### DIFF
--- a/nuxeo-java-client-test/src/main/resources/OSGI-INF/javaclient-portal-sso-login-contrib.xml
+++ b/nuxeo-java-client-test/src/main/resources/OSGI-INF/javaclient-portal-sso-login-contrib.xml
@@ -26,7 +26,10 @@
   <extension point="specificChains" target="org.nuxeo.ecm.platform.ui.web.auth.service.PluggableAuthenticationService">
     <specificAuthenticationChain name="Automation">
       <urlPatterns>
+        <!-- used in Builder#connect method -->
         <url>(.*)/automation.*</url>
+        <!-- used in ITUpload#itCanUploadFilesWithPortalSSOAuthentication -->
+        <url>(.*)/upload.*</url>
       </urlPatterns>
       <replacementChain>
         <plugin>AUTOMATION_BASIC_AUTH</plugin>

--- a/nuxeo-java-client-test/src/test/java/org/nuxeo/client/ITAuthentication.java
+++ b/nuxeo-java-client-test/src/test/java/org/nuxeo/client/ITAuthentication.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.nuxeo.client.objects.user.User;
 import org.nuxeo.client.spi.NuxeoClientRemoteException;
-import org.nuxeo.client.spi.auth.PortalSSOAuthInterceptor;
 
 /**
  * @since 0.1
@@ -68,10 +67,7 @@ public class ITAuthentication {
 
     @Test
     public void itCanChangeAuthMethod() {
-        NuxeoClient client = new NuxeoClient.Builder().url(ITBase.BASE_URL)
-                                                      .authentication(new PortalSSOAuthInterceptor("Administrator",
-                                                              "nuxeo5secretkey"))
-                                                      .connect();
+        NuxeoClient client = ITBase.createClientPortalSSO();
         User currentUser = client.getCurrentUser();
         assertEquals("Administrator", currentUser.getUserName());
     }

--- a/nuxeo-java-client-test/src/test/java/org/nuxeo/client/ITBase.java
+++ b/nuxeo-java-client-test/src/test/java/org/nuxeo/client/ITBase.java
@@ -38,13 +38,14 @@ import org.nuxeo.client.objects.user.UserManager;
 import org.nuxeo.client.objects.workflow.Workflow;
 import org.nuxeo.client.objects.workflow.Workflows;
 import org.nuxeo.client.spi.NuxeoClientRemoteException;
+import org.nuxeo.client.spi.auth.PortalSSOAuthInterceptor;
 import org.nuxeo.common.utils.FileUtils;
 
 /**
  * Tests the basic operation of client. This test is isolated from test framework because it unit tests the operation
  * used in framework to init server and to clean it.
  *
- * @since 3.0.0
+ * @since 3.0
  */
 public class ITBase {
 
@@ -228,20 +229,47 @@ public class ITBase {
         assertEquals("SerialDocumentReview", workflow.getName());
     }
 
+    /**
+     * @return A {@link NuxeoClient} filled with Nuxeo Server URL and default basic authentication.
+     */
     public static NuxeoClient createClient() {
         return createClient(LOGIN, PASSWORD);
     }
 
+    /**
+     * @return A {@link NuxeoClient} filled with Nuxeo Server URL and input basic authentication.
+     */
     public static NuxeoClient createClient(String login, String password) {
         return createClientBuilder(login, password).connect();
     }
 
+    /**
+     * @return A {@link NuxeoClient} filled with Nuxeo Server URL and default Portal SSO authentication.
+     */
+    public static NuxeoClient createClientPortalSSO() {
+        return createClientBuilderPortalSSO().connect();
+    }
+
+    /**
+     * @return A {@link NuxeoClient.Builder} filled with Nuxeo Server URL and default basic authentication.
+     */
     public static NuxeoClient.Builder createClientBuilder() {
         return createClientBuilder(LOGIN, PASSWORD);
     }
 
+    /**
+     * @return A {@link NuxeoClient.Builder} filled with Nuxeo Server URL and input basic authentication.
+     */
     public static NuxeoClient.Builder createClientBuilder(String login, String password) {
         return new NuxeoClient.Builder().url(BASE_URL).authentication(login, password).timeout(60);
+    }
+
+    /**
+     * @return A {@link NuxeoClient.Builder} filled with Nuxeo Server URL and default Portal SSO authentication.
+     */
+    public static NuxeoClient.Builder createClientBuilderPortalSSO() {
+        return new NuxeoClient.Builder().url(BASE_URL).authentication(
+                new PortalSSOAuthInterceptor("Administrator", "nuxeo5secretkey"));
     }
 
     public static User createUser() {

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/NuxeoClient.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/NuxeoClient.java
@@ -369,6 +369,8 @@ public class NuxeoClient extends AbstractBase<NuxeoClient> {
 
         protected final NuxeoConverterFactory converterFactory;
 
+        protected Interceptor authenticationMethod;
+
         protected NuxeoResponseCache cache;
 
         public Builder() {
@@ -393,7 +395,12 @@ public class NuxeoClient extends AbstractBase<NuxeoClient> {
         }
 
         public Builder authentication(Interceptor authenticationMethod) {
-            okhttpBuilder.addInterceptor(authenticationMethod);
+            this.authenticationMethod = authenticationMethod;
+            return this;
+        }
+
+        public Builder interceptor(Interceptor interceptor) {
+            okhttpBuilder.addInterceptor(interceptor);
             return this;
         }
 
@@ -417,6 +424,11 @@ public class NuxeoClient extends AbstractBase<NuxeoClient> {
          * Builds a {@link NuxeoClient} and log it, it will throw a {@link NuxeoClientException} if failed.
          */
         public NuxeoClient connect() {
+            // check authentication
+            if (authenticationMethod == null) {
+                throw new NuxeoClientException("Your client need an authentication method to connect to Nuxeo server");
+            }
+            okhttpBuilder.interceptors().add(0, authenticationMethod);
             // init client
             NuxeoClient client = new NuxeoClient(this);
             // login client on server

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/objects/upload/BatchUpload.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/objects/upload/BatchUpload.java
@@ -196,7 +196,9 @@ public class BatchUpload extends AbstractConnectable<BatchUploadAPI, BatchUpload
 
     public BatchUpload fetchBatchUpload(String fileIdx) {
         BatchUpload response = fetchResponse(api.fetchBatchUpload(batchId, fileIdx));
-        response.name = name;
+        if (name != null) {
+            response.name = name;
+        }
         response.batchId = batchId;
         response.fileIdx = fileIdx;
         return response;

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/spi/NuxeoClientRemoteException.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/spi/NuxeoClientRemoteException.java
@@ -19,6 +19,8 @@
  */
 package org.nuxeo.client.spi;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -76,6 +78,17 @@ public class NuxeoClientRemoteException extends NuxeoClientException {
 
     public String getErrorBody() {
         return errorBody;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder(getClass().getName());
+        s.append(": HTTP/").append(status);
+        String message = getLocalizedMessage();
+        if (StringUtils.isNotBlank(message)) {
+            s.append(": ").append(message);
+        }
+        return s.toString();
     }
 
 }

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/spi/auth/PortalSSOAuthInterceptor.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/spi/auth/PortalSSOAuthInterceptor.java
@@ -47,7 +47,7 @@ public class PortalSSOAuthInterceptor implements Interceptor {
         this.secret = secret;
     }
 
-    protected Headers computeHeaders() {
+    protected Headers computeHeaders(Headers headers) {
         // compute token
         long ts = new Date().getTime();
         long random = new Random(ts).nextInt();
@@ -63,11 +63,12 @@ public class PortalSSOAuthInterceptor implements Interceptor {
         }
 
         String base64HashedToken = Base64.encode(hashedToken);
-        return new Headers.Builder().add(HttpHeaders.NX_TS, String.valueOf(ts))
-                                    .add(HttpHeaders.NX_RD, String.valueOf(random))
-                                    .add(HttpHeaders.NX_TOKEN, base64HashedToken)
-                                    .add(HttpHeaders.NX_USER, username)
-                                    .build();
+        return headers.newBuilder()
+                      .add(HttpHeaders.NX_TS, String.valueOf(ts))
+                      .add(HttpHeaders.NX_RD, String.valueOf(random))
+                      .add(HttpHeaders.NX_TOKEN, base64HashedToken)
+                      .add(HttpHeaders.NX_USER, username)
+                      .build();
     }
 
     @Override
@@ -75,7 +76,7 @@ public class PortalSSOAuthInterceptor implements Interceptor {
         Request original = chain.request();
         Request request = chain.request()
                                .newBuilder()
-                               .headers(computeHeaders())
+                               .headers(computeHeaders(original.headers()))
                                .method(original.method(), original.body())
                                .build();
         return chain.proceed(request);


### PR DESCRIPTION
…nt and fix the portal sso method.
The fix on PortalSSO method is about reusing the http header previously built by OKHttp. We can do it because we force to use only one authentication method.