### PR TITLE
Fix NPE when media type is null

### DIFF
--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/MediaType.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/MediaType.java
@@ -40,6 +40,8 @@ public final class MediaType {
 
     private static final Pattern PARAMETER = Pattern.compile(";\\s*(?:" + TOKEN + "=(?:" + TOKEN + "|" + QUOTED + "))?");
 
+    private static final MediaType DEFAULT = MediaTypes.APPLICATION_OCTET_STREAM;
+
     private final String originalString;
 
     private final String type;
@@ -135,7 +137,7 @@ public final class MediaType {
 
     public static MediaType fromOkHttpMediaType(okhttp3.MediaType mediaType) {
         if (mediaType == null) {
-            return null;
+            return DEFAULT;
         }
         return parse(mediaType.toString());
     }

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/marshaller/NuxeoResponseConverterFactory.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/marshaller/NuxeoResponseConverterFactory.java
@@ -75,7 +75,7 @@ public final class NuxeoResponseConverterFactory<T> implements Converter<Respons
         MediaType mediaType = MediaType.fromOkHttpMediaType(body.contentType());
         if (!MediaTypes.APPLICATION_JSON.equalsTypeSubType(mediaType)
                 && !MediaTypes.APPLICATION_JSON_NXENTITY.equalsTypeSubType(mediaType)) {
-            if (mediaType.type().equals(MediaTypes.MULTIPART_S)) {
+            if (mediaType != null && mediaType.type().equals(MediaTypes.MULTIPART_S)) {
                 List<Blob> blobs = new ArrayList<>();
                 try (InputStream is = body.byteStream()) {
                     MimeMultipart mp = new MimeMultipart(new ByteArrayDataSource(is, mediaType.toString()));

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/marshaller/NuxeoResponseConverterFactory.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/marshaller/NuxeoResponseConverterFactory.java
@@ -75,7 +75,7 @@ public final class NuxeoResponseConverterFactory<T> implements Converter<Respons
         MediaType mediaType = MediaType.fromOkHttpMediaType(body.contentType());
         if (!MediaTypes.APPLICATION_JSON.equalsTypeSubType(mediaType)
                 && !MediaTypes.APPLICATION_JSON_NXENTITY.equalsTypeSubType(mediaType)) {
-            if (mediaType != null && mediaType.type().equals(MediaTypes.MULTIPART_S)) {
+            if (mediaType.type().equals(MediaTypes.MULTIPART_S)) {
                 List<Blob> blobs = new ArrayList<>();
                 try (InputStream is = body.byteStream()) {
                     MimeMultipart mp = new MimeMultipart(new ByteArrayDataSource(is, mediaType.toString()));


### PR DESCRIPTION
Hello,

I encounter a case where an operation returns a `Blob` without media type. In this case, this class fails with an NPE.