### PR TITLE
JAVACLIENT-253: Add syncIndexing() API to force synchronous search indexing

### DIFF
--- a/nuxeo-java-client-test/src/test/java/org/nuxeo/client/ITBase.java
+++ b/nuxeo-java-client-test/src/test/java/org/nuxeo/client/ITBase.java
@@ -266,6 +266,19 @@ public class ITBase {
                 userAgent.startsWith("okhttp/" + okhttpVersion + " NuxeoJavaClient/"));
     }
 
+    @Test
+    public void itCanSendSyncIndexingHeaders() {
+        // configure syncIndexing first, then bind capture interceptor after so it's last in the chain
+        client.syncIndexing();
+        SyncIndexingInterceptor interceptor = new SyncIndexingInterceptor();
+        client.addOkHttpInterceptor(interceptor);
+        // do a call - capture interceptor sees headers set by prior interceptors in the chain
+        client.repository().fetchDocumentRoot();
+
+        assertEquals("true", interceptor.searchSync);
+        assertEquals("true", interceptor.esSync);
+    }
+
     /**
      * @return A {@link NuxeoClient} filled with Nuxeo Server URL and default basic authentication.
      */
@@ -358,6 +371,22 @@ public class ITBase {
         public Response intercept(Chain chain) throws IOException {
             Request request = chain.request();
             userAgent = request.header(HttpHeaders.USER_AGENT);
+            return chain.proceed(request);
+        }
+
+    }
+
+    public static class SyncIndexingInterceptor implements Interceptor {
+
+        public String searchSync;
+
+        public String esSync;
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            Request request = chain.request();
+            searchSync = request.header(HttpHeaders.NX_SEARCH_SYNC);
+            esSync = request.header(HttpHeaders.NX_ES_SYNC);
             return chain.proceed(request);
         }
 

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/HttpHeaders.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/HttpHeaders.java
@@ -46,8 +46,14 @@ public class HttpHeaders {
 
     public static final String NX_TS = "NX_TS";
 
-    /** @since 3.2 */
+    /**
+     * @since 3.2
+     * @see #NX_SEARCH_SYNC for the modern equivalent (2025+)
+     */
     public static final String NX_ES_SYNC = "nx_es_sync";
+
+    /** @since 4.1 */
+    public static final String NX_SEARCH_SYNC = "nx-search-sync";
 
     /** @since 3.1 */
     public static final String USER_AGENT = "User-Agent";

--- a/nuxeo-java-client/src/main/java/org/nuxeo/client/objects/AbstractBase.java
+++ b/nuxeo-java-client/src/main/java/org/nuxeo/client/objects/AbstractBase.java
@@ -20,7 +20,6 @@ package org.nuxeo.client.objects;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -214,6 +213,19 @@ public class AbstractBase<B extends AbstractBase<B>> {
 
     public B transactionTimeout(long timeout) {
         return header(HttpHeaders.NUXEO_TX_TIMEOUT, String.valueOf(timeout));
+    }
+
+    /**
+     * Force synchronous search indexing during a REST call.
+     * <p>
+     * This ensures that any indexing triggered by the call is completed before the response is returned, providing
+     * read-after-write consistency for subsequent search-based queries.
+     *
+     * @since 4.1
+     */
+    public B syncIndexing() {
+        header(HttpHeaders.NX_SEARCH_SYNC, "true");
+        return header(HttpHeaders.NX_ES_SYNC, "true");
     }
 
     public B enrichers(boolean append, String type, String enricher, String... enrichers) {


### PR DESCRIPTION
## Summary

Following [NXP-33628](https://hyland.atlassian.net/browse/NXP-33628) which moves the comments page provider to ES, add a `syncIndexing()` fluent method to force synchronous search indexing during REST calls.

- Add `HttpHeaders.NX_SEARCH_SYNC` constant (`nx-search-sync`) for 2025+ servers
- Add `syncIndexing()` method on `AbstractBase` that sets both `nx-search-sync` and `nx_es_sync` headers for backward compat across 2023/2025
- Add integration test verifying both headers are sent

### Usage

```java
doc.adapter(CommentAdapter::new).syncIndexing().create(comment);
```

JIRA: [JAVACLIENT-253](https://hyland.atlassian.net/browse/JAVACLIENT-253)

[NXP-33628]: https://hyland.atlassian.net/browse/NXP-33628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JAVACLIENT-253]: https://hyland.atlassian.net/browse/JAVACLIENT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ